### PR TITLE
update menu strings to enable ampersands to display correctly

### DIFF
--- a/main.js
+++ b/main.js
@@ -499,7 +499,7 @@ function buildMenu() {
         },
         { label: 'Email Settings…', click: () => sendToWindow({ type: 'emailSettings' }) },
         {
-          label: 'Goals & Settings…',
+          label: 'Goals && Settings…',
           accelerator: 'CmdOrCtrl+,',
           click: () => sendToWindow({ type: 'stats' })
         },
@@ -522,7 +522,7 @@ function buildMenu() {
         { role: 'pasteAndMatchStyle' }, { role: 'selectAll' },
         { type: 'separator' },
         {
-          label: 'Find & Replace',
+          label: 'Find && Replace…',
           accelerator: 'CmdOrCtrl+F',
           click: () => sendToWindow({ type: 'find' })
         },


### PR DESCRIPTION
I noticed that the ampersands (&) were not displaying correctly in the menus, due to an escaping issue in Electron. Doubling the character is the solution. 

I also added the ellipsis to the 'Find & Replace' since it brings up a dialog box.

<img width="245" height="233" alt="Screenshot 2026-08-10 at 1 16 30 PM" src="https://github.com/user-attachments/assets/32d55020-dcdb-444c-ad4b-95930c088f29" />
<img width="288" height="246" alt="Screenshot 2026-08-10 at 1 30 26 PM" src="https://github.com/user-attachments/assets/12820069-a94b-443c-a222-dad64045ed26" />
