### PR TITLE
Experimental Linux support: AppImage/deb/rpm installers and platform polish

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ No frameworks, just four files:
 - `app.js` — the entire UI: bookshelf, editor, outline, search, goals, the Silo. Organized in commented sections.
 - `styles.css` — all styling, with CSS variables for the palette at the top.
 
-Books are folders of plain files in `~/Documents/NEO Library`: `book.json` for metadata, `chapters/*.html` for text, JSON files for darlings/stickies.
+Books are folders of plain files in `~/Documents/NEO Library` (or your OS 'Documents' convention): `book.json` for metadata, `chapters/*.html` for text, JSON files for darlings/stickies.
 
 ## Ground rules for the writing experience
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Grab the latest installer from the **[Releases page](../../releases)**:
 
 - **macOS** — download the `.dmg`, open it, drag NEO to Applications.
 - **Windows** — download the `.exe` installer and run it. (This version is not as tested!) Defender might eat this file, so add the folder to your exclusions or look in your threat history and get NEO.exe out of quarantine.
+- **Linux** — download the `.AppImage`, make it executable (right-click → Properties, or `chmod +x`), and run it. There's also a `.deb` (Ubuntu/Mint) and an `.rpm` (Fedora). (Community contribution; this version is not tested!)
 
 ## What makes NEO different
 
@@ -39,7 +40,7 @@ Grab the latest installer from the **[Releases page](../../releases)**:
 
 ## Your files are yours
 
-Everything lives in `~/Documents/NEO Library` — a folder per book, chapters as readable HTML, metadata as JSON. Open them in any text editor.
+Everything lives in `~/Documents/NEO Library` (or your OS Documents convention) — a folder per book, chapters as readable HTML, metadata as JSON. Open them in any text editor.
 
 ## Building from source (for the eggheads):
 
@@ -52,7 +53,7 @@ npm install
 npm start
 ```
 
-To build installers: `npm install electron-builder --save-dev`, then `npm run package` (macOS), `npm run package:win` (Windows), or `npm run package:all`. Output lands in `dist/`.
+To build installers: `npm install electron-builder --save-dev`, then `npm run package` (macOS), `npm run package:win` (Windows), `npm run package:linux` (Linux — AppImage, .deb, and .rpm), or `npm run package:all`. Output lands in `dist/`.
 
 The app is deliberately simple: an Electron shell (`main.js`), a preload bridge (`preload.js`), and a single-file renderer (`app.js` + `styles.css` + `index.html`). If you can read JavaScript, you can change NEO. Have at it. Build me a better mousetrap.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -4,7 +4,9 @@ Warning! This tutorial is a very rough draft!
 
 **Installing**
 
-Mac: open the .dmg, drag NEO into Applications. PC: run the installer. For PC, you might get a warning. I haven't tested the .exe version very much, so beware!
+Mac: open the .dmg, drag NEO into Applications. PC: run the installer. For PC, you might get a warning. I haven't tested the .exe version very much, so beware! Linux: grab the .AppImage, make it executable, double-click, or install the .deb/.rpm.
+
+(One note: the shortcuts below use the Mac ⌘ key. On PC and Linux, that's Ctrl — the app will show the right keys for your environment.)
 
 NEO will ask you two things when it opens: your name (this goes on your title pages, and you can leave it blank and be Anonymous), and whether you're a **pantser or a plotter**. If you don't know the difference, pantsers write by the seat of their pants and figure our the story as they go. Plotters outline first. There's no wrong answer, and you can change it later. The difference in NEO is plotters have new books that open in the Outline tab, while pantsers get a blank page. Then NEO asks you to pick a font and a drop cap style, shows you exactly what your page will look like, and never asks you anything again. You can change these options later.
 

--- a/app.js
+++ b/app.js
@@ -18,6 +18,8 @@ let hintShown = false;
 const $ = (sel) => document.querySelector(sel);
 const $$ = (sel) => Array.from(document.querySelectorAll(sel));
 
+const isMac = window.neo.platform === 'darwin';
+
 // ---------- tiny modal helper (Electron has no window.prompt) ----------
 function askInput(title, placeholder, value = '') {
   return new Promise((resolve) => {
@@ -2709,7 +2711,7 @@ async function doExport(format) {
 
 function chooseEmailMethod() {
   // Apple Mail only exists on Macs; elsewhere Gmail is the only offer
-  if (!navigator.platform.toLowerCase().includes('mac')) return Promise.resolve('gmail');
+  if (!isMac) return Promise.resolve('gmail');
   return new Promise((resolve) => {
     const bd = document.createElement('div');
     bd.className = 'modal-backdrop';

--- a/app.js
+++ b/app.js
@@ -2729,7 +2729,7 @@ async function doExport(format) {
   else if (format === 'epub') payload = { format, defaultName, zipEntries: buildEpubEntries() };
   else payload = { format, defaultName, content: format === 'txt' ? buildTxt() : format === 'md' ? buildMd() : buildHtml() };
   const saved = await window.neo.exportSave(payload);
-  if (saved) toast('Exported: ' + saved.split('/').pop());
+  if (saved) toast('Exported: ' + saved.split(/[\\/]/).pop()); // both slashes: Windows paths too
 }
 
 function chooseEmailMethod() {

--- a/app.js
+++ b/app.js
@@ -2773,6 +2773,7 @@ async function manuscriptHash() {
 
 async function doEmailDraft() {
   if (!book) { toast('Open a book first'); return; }
+  if (!isMac && library.emailMethod === 'mail') library.emailMethod = 'gmail'; // Apple Mail didn't make the trip
   flushAllSaves();
   if (!library.emailAddress || !library.emailMethod) {
     const ok = await emailSettings();

--- a/app.js
+++ b/app.js
@@ -743,7 +743,9 @@ function cleanPasteHtml(html) {
 
 // Em dash, ellipsis, smart quotes — without ever leaving the keyboard.
 function smartKeys(e, body) {
-  if (e.metaKey || e.ctrlKey || e.altKey) return;
+  // AltGr (Win/Linux) arrives as Ctrl+Alt — that's typing, not a chord.
+  const altGr = !isMac && e.getModifierState('AltGraph');
+  if (!altGr && (e.metaKey || e.ctrlKey || e.altKey)) return;
   if (e.isComposing || e.keyCode === 229) return;
 
   const sel = window.getSelection();

--- a/app.js
+++ b/app.js
@@ -24,6 +24,11 @@ const isMac = window.neo.platform === 'darwin';
 // on Win/Linux it would just swallow clicks along the top edge.
 if (!isMac) $('#dragstrip').remove();
 
+// ⌘⇧X reads like scripture on a Mac; everyone else gets Ctrl+Shift+X.
+const keys = isMac ? (s) => s
+  : (s) => s.replace(/⌘/g, 'Ctrl+').replace(/⇧/g, 'Shift+').replace(/⌥/g, 'Alt+');
+if (!isMac) $$('[title]').forEach((el) => { el.title = keys(el.title); });
+
 // ---------- tiny modal helper (Electron has no window.prompt) ----------
 function askInput(title, placeholder, value = '') {
   return new Promise((resolve) => {
@@ -495,7 +500,7 @@ async function openBook(bookId) {
 
   if (!hintShown) {
     hintShown = true;
-    setTimeout(() => toast('Enter twice = section break · three times = new chapter · ⌘/ shows everything else', 7000), 800);
+    setTimeout(() => toast(keys('Enter twice = section break · three times = new chapter · ⌘/ shows everything else'), 7000), 800);
   }
 }
 
@@ -573,7 +578,7 @@ async function deleteChapterToDarlings(chId) {
   }
   if (currentChapterId === chId) currentChapterId = null;
   await deleteChapterQuiet(chId);
-  if (text) toast('Chapter removed — its words are in Darlings, or ⌘Z to undo');
+  if (text) toast(keys('Chapter removed — its words are in Darlings, or ⌘Z to undo'));
 }
 
 async function chapterMenu(chId, index) {
@@ -875,7 +880,7 @@ function insertPlaceholder() {
   if (el && el.nodeType === Node.TEXT_NODE) el = el.parentElement;
   const bodyEl = el && el.closest ? el.closest('.chapter-body') : null;
   if (!bodyEl) {
-    toast('Click into a chapter first, then ⌘⇧X drops a placeholder');
+    toast(keys('Click into a chapter first, then ⌘⇧X drops a placeholder'));
     return;
   }
   currentChapterId = bodyEl.closest('.chapter').dataset.id;
@@ -911,7 +916,7 @@ function renderStickies() {
   wrap.innerHTML = '';
   const open = stickies.filter((s) => !s.resolved);
   if (open.length === 0) {
-    wrap.innerHTML = `<div class="stickies-empty">No notes yet.<br><br>Hit ⌘⇧X while writing to drop a placeholder — a “come back to this” mark that never breaks your flow.</div>`;
+    wrap.innerHTML = keys(`<div class="stickies-empty">No notes yet.<br><br>Hit ⌘⇧X while writing to drop a placeholder — a “come back to this” mark that never breaks your flow.</div>`);
     return;
   }
   for (const s of open) {
@@ -1076,7 +1081,7 @@ navList.addEventListener('drop', async (e) => {
   await saveMeta();
   renderChapters(); // renumbers heads and rebuilds the nav
   if (currentTab === 'outline') renderOutline();
-  toast('Chapters reordered — ⌘Z to undo');
+  toast(keys('Chapters reordered — ⌘Z to undo'));
 });
 
 function highlightNav() {
@@ -1195,14 +1200,14 @@ async function moveSelectionToDarlings(html, text) {
   });
   await window.neo.writeJSON(book.id, 'darlings', darlings);
   updateCounters();
-  toast('Saved to Darlings — kill without remorse (⌘Z to undo)');
+  toast(keys('Saved to Darlings — kill without remorse (⌘Z to undo)'));
 }
 
 // keyboard route: select a passage, ⌘⇧D, keep writing
 function darlingFromKeyboard() {
   const sel = window.getSelection();
   if (!sel.rangeCount || sel.isCollapsed) {
-    toast('Select the passage first, then ⌘⇧D sends it to Darlings');
+    toast(keys('Select the passage first, then ⌘⇧D sends it to Darlings'));
     return;
   }
   let el = sel.anchorNode;
@@ -1932,7 +1937,7 @@ function replaceAllMatches() {
     if (touched) syncChapter(body, chId);
   }
   if (n === 0) undoStack.pop(); // nothing changed, nothing to undo
-  toast(n ? `${n} replaced across the whole book — ⌘Z to undo` : '0 replaced');
+  toast(n ? keys(`${n} replaced across the whole book — ⌘Z to undo`) : '0 replaced');
   runSearch();
 }
 
@@ -2021,7 +2026,7 @@ function toggleSpellcheck() {
   const active = document.activeElement;
   if (active && active.blur) { active.blur(); if (active.focus) active.focus(); }
   toast(spellOn
-    ? 'Spellcheck pass ON — right-click any squiggle for suggestions. ⌘; again when you’re done.'
+    ? keys('Spellcheck pass ON — right-click any squiggle for suggestions. ⌘; again when you’re done.')
     : 'Spellcheck off. Back to flow.', 5000);
 }
 
@@ -2315,7 +2320,7 @@ function applyFonts() {
 }
 
 function showHelp() {
-  const row = (k, d) => `<span class="hk">${k}</span><span>${d}</span>`;
+  const row = (k, d) => `<span class="hk">${keys(k)}</span><span>${d}</span>`;
   const bd = document.createElement('div');
   bd.className = 'modal-backdrop';
   bd.innerHTML = `

--- a/app.js
+++ b/app.js
@@ -2122,7 +2122,7 @@ function exitSiloAttempt() {
     <div class="modal" style="width:520px">
       <h2 style="font-size:16px">Leaving the Silo?</h2>
       <p>Type this, word for word, and the hatch opens:</p>
-      <p style="font-family:Georgia,serif;font-size:15px;font-style:italic;color:var(--accent);line-height:1.6">“${prompt}”</p>
+      <p style="font-family:Georgia,'Noto Serif',serif;font-size:15px;font-style:italic;color:var(--accent);line-height:1.6">“${prompt}”</p>
       <input id="silo-input" type="text" spellcheck="false" autocomplete="off" placeholder="Confess…"/>
       <div style="display:flex;justify-content:space-between;align-items:center;margin-top:14px">
         <button class="m-cancel" style="background:var(--accent);border:none;border-radius:6px;padding:7px 16px;color:#191919">Never mind — back to writing</button>
@@ -2302,17 +2302,20 @@ $('#goal-counter').onclick = openStats;
 /*  MENU: Help + fonts                                                 */
 /* ================================================================== */
 
+// Mac names first; then free lookalikes most Linux desktops ship
+// (urw-base35 clones: P052 = Palatino, C059 = Century Schoolbook,
+//  URW Gothic = Futura-ish, Z003 = chancery script).
 const DROPCAP_FONTS = {
-  literary: '"Didot", "Bodoni 72", Georgia, serif',
-  fantasy: '"Apple Chancery", "Snell Roundhand", cursive',
-  scifi: 'Futura, "Avenir Next", "Helvetica Neue", sans-serif'
+  literary: '"Didot", "Bodoni 72", "Noto Serif Display", Georgia, "Noto Serif", serif',
+  fantasy: '"Apple Chancery", "Snell Roundhand", "URW Chancery L", "Z003", cursive',
+  scifi: 'Futura, "Avenir Next", "URW Gothic", "Century Gothic", "Helvetica Neue", "DejaVu Sans", sans-serif'
 };
 const BODY_FONTS = {
-  'Georgia': 'Georgia, "Times New Roman", serif',
-  'Palatino': '"Palatino", "Palatino Linotype", serif',
-  'Baskerville': 'Baskerville, Georgia, serif',
-  'Hoefler Text': '"Hoefler Text", Georgia, serif',
-  'Iowan Old Style': '"Iowan Old Style", Georgia, serif'
+  'Georgia': 'Georgia, "Noto Serif", "Liberation Serif", "Times New Roman", serif',
+  'Palatino': '"Palatino", "Palatino Linotype", "URW Palladio L", "P052", "TeX Gyre Pagella", serif',
+  'Baskerville': 'Baskerville, "Libertinus Serif", "Linux Libertine", "C059", Georgia, serif',
+  'Hoefler Text': '"Hoefler Text", "C059", "Century Schoolbook L", Georgia, "Noto Serif", serif',
+  'Iowan Old Style': '"Iowan Old Style", "Bitstream Charter", "Charter", "Noto Serif", Georgia, serif'
 };
 
 function applyFonts() {
@@ -2445,7 +2448,7 @@ function buildHtml() {
   return `<!DOCTYPE html>
 <html><head><meta charset="utf-8"><title>${book.title}</title>
 <style>
-  body { font-family: Georgia, serif; color: #1c1c1c; max-width: 620px; margin: 40px auto; line-height: 1.7; font-size: 13pt; }
+  body { font-family: Georgia, "Noto Serif", "Liberation Serif", serif; color: #1c1c1c; max-width: 620px; margin: 40px auto; line-height: 1.7; font-size: 13pt; }
   .titlepage { text-align: center; margin: 30vh 0 20vh; page-break-after: always; }
   .titlepage h1 { font-size: 30pt; margin: 0; }
   .titlepage .sub { font-style: italic; color: #555; }
@@ -2574,7 +2577,7 @@ function makeCoverJpeg() {
   ctx.textAlign = 'center';
   ctx.shadowColor = 'rgba(0,0,0,0.45)';
   ctx.shadowBlur = 18;
-  ctx.font = 'bold 150px Georgia';
+  ctx.font = 'bold 150px Georgia, "Noto Serif", serif';
   const words = (book.title || 'Untitled').split(/\s+/);
   const lines = [];
   let line = '';
@@ -2586,7 +2589,7 @@ function makeCoverJpeg() {
   lines.push(line);
   let y = H * 0.32;
   for (const l of lines) { ctx.fillText(l, W / 2, y); y += 175; }
-  ctx.font = '72px Georgia';
+  ctx.font = '72px Georgia, "Noto Serif", serif';
   ctx.fillText((book.author || '').toUpperCase(), W / 2, H * 0.82);
   return canvas.toDataURL('image/jpeg', 0.86).split(',')[1];
 }

--- a/app.js
+++ b/app.js
@@ -401,7 +401,7 @@ function bookTile(meta) {
     const choice = await optionModal(`“${meta.title}”`, null, [
       { label: 'Set word goal…', desc: 'Adds the subtle progress bar to the cover.', value: 'goal' },
       { label: 'Remove from bookshelf', desc: 'Takes it off your shelves. The files stay safe in your NEO Library folder on disk.', value: 'remove' },
-      { label: 'Move to Trash', desc: 'Sends the book folder to your Mac Trash.', danger: true, value: 'trash' }
+      { label: 'Move to Trash', desc: 'Sends the book folder to the Trash.', danger: true, value: 'trash' }
     ]);
     if (choice === 'goal') {
       const goal = await askInput(`Word count goal for “${meta.title}”`, 'e.g. 80000 — blank removes the goal',
@@ -2785,7 +2785,7 @@ async function doEmailDraft() {
     + `Sent from NEO on ${new Date().toLocaleString()}.\n\n`
     + `SHA-256 fingerprint of the manuscript text:\n${hash}\n\n`
     + (library.emailMethod === 'gmail'
-      ? 'The PDF snapshot is in the Finder window NEO just opened — drag it into this email before sending.'
+      ? 'The PDF snapshot is in the folder NEO just opened — drag it into this email before sending.'
       : 'PDF snapshot attached.');
   toast('Preparing your draft…');
   const res = await window.neo.emailDraft({

--- a/app.js
+++ b/app.js
@@ -29,6 +29,15 @@ const keys = isMac ? (s) => s
   : (s) => s.replace(/⌘/g, 'Ctrl+').replace(/⇧/g, 'Shift+').replace(/⌥/g, 'Alt+');
 if (!isMac) $$('[title]').forEach((el) => { el.title = keys(el.title); });
 
+// GTK claims Ctrl+/ for select-all before the menu accelerator ever sees it,
+// so the shortcut cheat-sheet needs a hand off-mac.
+if (!isMac) document.addEventListener('keydown', (e) => {
+  if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && e.key === '/') {
+    e.preventDefault();
+    showHelp();
+  }
+});
+
 // ---------- tiny modal helper (Electron has no window.prompt) ----------
 function askInput(title, placeholder, value = '') {
   return new Promise((resolve) => {

--- a/app.js
+++ b/app.js
@@ -20,6 +20,10 @@ const $$ = (sel) => Array.from(document.querySelectorAll(sel));
 
 const isMac = window.neo.platform === 'darwin';
 
+// macOS is frameless (hiddenInset) and needs the drag strip; framed windows don't —
+// on Win/Linux it would just swallow clicks along the top edge.
+if (!isMac) $('#dragstrip').remove();
+
 // ---------- tiny modal helper (Electron has no window.prompt) ----------
 function askInput(title, placeholder, value = '') {
   return new Promise((resolve) => {

--- a/main.js
+++ b/main.js
@@ -269,6 +269,13 @@ ipcMain.handle('email:draft', async (_e, { to, subject, body, html, defaultName,
     return { ok: true, method: 'gmail', file };
   }
 
+  if (process.platform !== 'darwin') {
+    // A 'mail' choice that drifted over from a Mac (synced library) —
+    // there is no Apple Mail here; reveal the snapshot instead.
+    shell.showItemInFolder(file);
+    return { ok: false, file };
+  }
+
   const esc = (s) => String(s).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
   const script = `
     tell application "Mail"

--- a/main.js
+++ b/main.js
@@ -188,12 +188,13 @@ ipcMain.handle('silo:set', (e, on) => {
   win.__silo = on;
   if (on) {
     if (win.isFullScreen()) win.setFullScreen(false);
-    win.setKiosk(true);
-    win.setAlwaysOnTop(true, 'screen-saver');
+    try { win.setKiosk(true); } catch { win.setFullScreen(true); } // kiosk or die trying — fullscreen is the floor
+    try { win.setAlwaysOnTop(true, 'screen-saver'); } catch { /* Wayland has no "above" — best effort */ }
     win.focus();
   } else {
-    win.setAlwaysOnTop(false);
-    win.setKiosk(false);
+    try { win.setAlwaysOnTop(false); } catch {}
+    try { win.setKiosk(false); } catch {}
+    if (process.platform !== 'darwin' && win.isFullScreen()) win.setFullScreen(false); // undo the fallback
   }
   return true;
 });

--- a/main.js
+++ b/main.js
@@ -12,8 +12,20 @@ const isMac = process.platform === 'darwin';
 // ---------------------------------------------------------------------------
 // Library location: a folder of plain files the user can inspect, sync, back up.
 // ---------------------------------------------------------------------------
-const LIBRARY_DIR = path.join(os.homedir(), 'Documents', 'NEO Library');
-const LIBRARY_FILE = path.join(LIBRARY_DIR, 'library.json');
+let LIBRARY_DIR = path.join(os.homedir(), 'Documents', 'NEO Library');
+let LIBRARY_FILE = path.join(LIBRARY_DIR, 'library.json');
+
+// "Documents" is not always ~/Documents: XDG dirs on Linux, OneDrive redirection
+// on Windows. Ask the OS once we can — but an existing library stays put.
+function resolveLibraryDir() {
+  let docs;
+  try { docs = app.getPath('documents'); } catch { return; } // OS won't say? keep the default
+  const dir = path.join(docs, 'NEO Library');
+  if (dir === LIBRARY_DIR) return;
+  if (fs.existsSync(LIBRARY_FILE)) return; // a legacy ~/Documents library exists — don't strand it
+  LIBRARY_DIR = dir;
+  LIBRARY_FILE = path.join(dir, 'library.json');
+}
 
 function ensureLibrary() {
   if (!fs.existsSync(LIBRARY_DIR)) fs.mkdirSync(LIBRARY_DIR, { recursive: true });
@@ -233,7 +245,7 @@ async function buildZip(zipEntries) {
 ipcMain.handle('export:save', async (_e, { format, defaultName, content, zipEntries }) => {
   const win = BrowserWindow.getFocusedWindow();
   const { canceled, filePath } = await dialog.showSaveDialog(win, {
-    defaultPath: path.join(os.homedir(), 'Documents', defaultName + '.' + format),
+    defaultPath: path.join(app.getPath('documents'), defaultName + '.' + format),
     filters: [{ name: format.toUpperCase(), extensions: [format] }]
   });
   if (canceled || !filePath) return null;
@@ -655,6 +667,7 @@ app.whenReady().then(() => {
       logError('prefs', err);
     }
   }
+  resolveLibraryDir();
   ensureLibrary();
   buildMenu();
   createWindow();

--- a/main.js
+++ b/main.js
@@ -167,8 +167,20 @@ ipcMain.handle('book:delete', async (_e, bookId, title) => {
   });
   if (response === 1) {
     const { shell } = require('electron');
-    await shell.trashItem(bookDir(bookId));
-    return true;
+    try {
+      await shell.trashItem(bookDir(bookId));
+      return true;
+    } catch (err) {
+      // Some filesystems have no Trash (network mounts, odd drives).
+      // Words are never lost: leave the book alone and show the writer where it lives.
+      logError('trash', err);
+      shell.showItemInFolder(bookDir(bookId));
+      dialog.showMessageBox(win, {
+        message: 'NEO couldn’t move that folder to the Trash.',
+        detail: 'The book is untouched. Its folder is highlighted so you can deal with it yourself.'
+      });
+      return false;
+    }
   }
   return false;
 });

--- a/main.js
+++ b/main.js
@@ -7,6 +7,8 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 
+const isMac = process.platform === 'darwin';
+
 // ---------------------------------------------------------------------------
 // Library location: a folder of plain files the user can inspect, sync, back up.
 // ---------------------------------------------------------------------------
@@ -422,7 +424,10 @@ function createWindow() {
     height: 800,
     minWidth: 800,
     minHeight: 600,
-    titleBarStyle: 'hiddenInset',
+    titleBarStyle: 'hiddenInset', // macOS-only; Win/Linux keep their native frame
+    autoHideMenuBar: true, // Win/Linux: the menu bar stays out of sight until Alt (no-op on macOS)
+    icon: process.platform === 'linux' && fs.existsSync(path.join(__dirname, 'build', 'icons', '512x512.png'))
+      ? path.join(__dirname, 'build', 'icons', '512x512.png') : undefined, // lights up if build/icons ever gains art
     backgroundColor: '#191919',
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
@@ -476,7 +481,7 @@ function sendToWindow(msg) {
 function buildMenu() {
   const bodyFonts = ['Georgia', 'Palatino', 'Baskerville', 'Hoefler Text', 'Iowan Old Style'];
   const template = [
-    { role: 'appMenu' },
+    ...(isMac ? [{ role: 'appMenu' }] : []), // the app menu's roles are macOS-only
     {
       label: 'File',
       submenu: [
@@ -510,7 +515,7 @@ function buildMenu() {
           click: () => sendToWindow({ type: 'import' })
         },
         { type: 'separator' },
-        { role: 'close' }
+        isMac ? { role: 'close' } : { role: 'quit' } // File → Quit is the Win/Linux idiom
       ]
     },
     {
@@ -578,7 +583,7 @@ function buildMenu() {
           accelerator: 'CmdOrCtrl+Shift+F',
           click: () => {
             const w = BrowserWindow.getFocusedWindow();
-            if (w && !w.isSimpleFullScreen()) w.setFullScreen(!w.isFullScreen());
+            if (w && !(isMac && w.isSimpleFullScreen())) w.setFullScreen(!w.isFullScreen()); // isSimpleFullScreen is macOS-only
           }
         },
         {
@@ -588,7 +593,7 @@ function buildMenu() {
         }
       ]
     },
-    { role: 'windowMenu' },
+    ...(isMac ? [{ role: 'windowMenu' }] : []), // zoom/front are macOS-only; Linux has a WM for this
     {
       label: 'Help',
       submenu: [

--- a/main.js
+++ b/main.js
@@ -227,10 +227,12 @@ ipcMain.handle('fullscreen:escape', (e) => {
 
 async function renderPDF(html) {
   const pdfWin = new BrowserWindow({ show: false, webPreferences: { sandbox: true } });
+  // Letter is a North American habit; most of the world prints A4.
+  const letterCountries = ['US', 'CA', 'MX', 'PH'];
   try {
     await pdfWin.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html));
     return await pdfWin.webContents.printToPDF({
-      pageSize: 'Letter',
+      pageSize: letterCountries.includes(app.getLocaleCountryCode()) ? 'Letter' : 'A4',
       margins: { top: 1, bottom: 1, left: 1, right: 1 },
       printBackground: false
     });

--- a/main.js
+++ b/main.js
@@ -151,7 +151,7 @@ ipcMain.handle('book:delete', async (_e, bookId, title) => {
     defaultId: 0,
     cancelId: 0,
     message: `Move “${title}” to the Trash?`,
-    detail: 'The book folder will go to your Mac Trash, so you can recover it.'
+    detail: 'The book folder will go to the Trash, so you can recover it.'
   });
   if (response === 1) {
     const { shell } = require('electron');

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "productName": "NEO",
   "version": "0.2.1",
   "description": "A word processor for authors. Distraction-free by default.",
+  "homepage": "https://github.com/hughhowey/neo",
   "main": "main.js",
   "scripts": {
     "start": "electron .",
     "package": "electron-builder --mac",
     "package:win": "electron-builder --win",
+    "package:linux": "electron-builder --linux",
     "package:all": "electron-builder --mac --win"
   },
   "build": {
@@ -36,6 +38,21 @@
     "nsis": {
       "oneClick": true,
       "deleteAppDataOnUninstall": false
+    },
+    "linux": {
+      "target": ["AppImage", "deb", "rpm"],
+      "category": "Office",
+      "synopsis": "A word processor for authors. Distraction-free by default.",
+      "maintainer": "Hugh Howey <hughhowey@users.noreply.github.com>",
+      "executableName": "neo",
+      "syncDesktopName": true,
+      "desktop": {
+        "entry": {
+          "Comment": "A word processor for authors. Distraction-free by default.",
+          "Keywords": "writing;writer;novel;book;author;manuscript;wordprocessor;",
+          "StartupWMClass": "neo"
+        }
+      }
     }
   },
   "author": "Hugh Howey",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,11 @@
       "deleteAppDataOnUninstall": false
     },
     "linux": {
-      "target": ["AppImage", "deb", "rpm"],
+      "target": [
+        { "target": "AppImage", "arch": ["x64", "arm64"] },
+        { "target": "deb", "arch": ["x64", "arm64"] },
+        { "target": "rpm", "arch": ["x64", "arm64"] }
+      ],
       "category": "Office",
       "synopsis": "A word processor for authors. Distraction-free by default.",
       "maintainer": "Hugh Howey <hughhowey@users.noreply.github.com>",

--- a/preload.js
+++ b/preload.js
@@ -1,6 +1,8 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('neo', {
+  platform: process.platform, // 'darwin' | 'win32' | 'linux'
+
   readLibrary: () => ipcRenderer.invoke('library:read'),
   writeLibrary: (data) => ipcRenderer.invoke('library:write', data),
   libraryPath: () => ipcRenderer.invoke('library:path'),

--- a/styles.css
+++ b/styles.css
@@ -10,8 +10,8 @@
   --muted: #8a8a8a;
   --pane: #202020;
   --red: #c0392b;
-  --body-font: Georgia, "Times New Roman", serif;
-  --dropcap-font: "Didot", "Bodoni 72", Georgia, serif;
+  --body-font: Georgia, "Noto Serif", "Liberation Serif", "Times New Roman", serif;
+  --dropcap-font: "Didot", "Bodoni 72", "Noto Serif Display", Georgia, "Noto Serif", serif;
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -20,7 +20,7 @@ html, body {
   height: 100%;
   background: var(--bg);
   color: #ddd;
-  font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, system-ui, "Segoe UI", Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   overflow: hidden;
   -webkit-font-smoothing: antialiased;
 }
@@ -98,7 +98,7 @@ button { font: inherit; cursor: pointer; }
 }
 /* the house cover style: crisp caps inside a thin frame */
 .book.cv-serif .b-title {
-  font-family: Optima, Candara, Georgia, serif;
+  font-family: Optima, Candara, "Noto Sans", Georgia, "Noto Serif", serif;
   font-size: 12px; font-weight: 700;
   letter-spacing: 1.2px; line-height: 1.45;
 }
@@ -249,11 +249,11 @@ body.night .ol-hint { color: #5f5b52; }
   display: flex; flex-direction: column; justify-content: center;
 }
 #tp-title {
-  font-family: Georgia, serif; font-size: 34px; font-weight: 700;
+  font-family: Georgia, "Noto Serif", "Liberation Serif", serif; font-size: 34px; font-weight: 700;
   outline: none; min-height: 44px;
 }
 #tp-subtitle {
-  font-family: Georgia, serif; font-size: 17px; font-style: italic;
+  font-family: Georgia, "Noto Serif", "Liberation Serif", serif; font-size: 17px; font-style: italic;
   color: #555; margin-top: 14px; outline: none; min-height: 24px;
 }
 #tp-author {
@@ -266,7 +266,7 @@ body.night .ol-hint { color: #5f5b52; }
 
 /* --- Chapters: each starts on a fresh sheet --- */
 .chapter-head {
-  text-align: center; font-family: Georgia, serif;
+  text-align: center; font-family: Georgia, "Noto Serif", "Liberation Serif", serif;
   font-size: 15px; letter-spacing: 4px; text-transform: uppercase;
   color: #555; margin-bottom: 44px;
   user-select: none;
@@ -314,12 +314,12 @@ body.night .ol-hint { color: #5f5b52; }
 
 /* --- Aux paper (Notes / Outline / Darlings) --- */
 #aux-paper h2 {
-  font-family: Georgia, serif; font-weight: 400; letter-spacing: 3px;
+  font-family: Georgia, "Noto Serif", "Liberation Serif", serif; font-weight: 400; letter-spacing: 3px;
   text-transform: uppercase; font-size: 14px; color: #777;
   text-align: center; margin-bottom: 40px;
 }
 #aux-editor {
-  font-family: Georgia, serif; font-size: var(--editor-size, 16px); line-height: 1.7; outline: none;
+  font-family: Georgia, "Noto Serif", "Liberation Serif", serif; font-size: var(--editor-size, 16px); line-height: 1.7; outline: none;
   min-height: 50vh;
 }
 #aux-editor:empty::before { content: 'Write freely…'; color: #b9b4a8; font-style: italic; }
@@ -329,12 +329,12 @@ body.night .ol-hint { color: #5f5b52; }
 .ol-chapter { margin-top: 18px; }
 .ol-section { margin-left: 40px; }
 .ol-num {
-  font-family: Georgia, serif; color: #8d8778; min-width: 24px; text-align: right;
+  font-family: Georgia, "Noto Serif", "Liberation Serif", serif; color: #8d8778; min-width: 24px; text-align: right;
   user-select: none; flex-shrink: 0;
 }
 .ol-chapter .ol-num { font-weight: 700; color: #6b6455; }
 .ol-text {
-  flex: 1; outline: none; font-family: Georgia, serif; font-size: 15px;
+  flex: 1; outline: none; font-family: Georgia, "Noto Serif", "Liberation Serif", serif; font-size: 15px;
   line-height: 1.5; min-height: 20px; border-bottom: 1px dashed transparent;
 }
 .ol-text:focus { border-bottom-color: #d8d2c2; }
@@ -355,11 +355,11 @@ body.night .ol-hint { color: #5f5b52; }
 .darling {
   border: 1px solid #e3ddcf; border-left: 3px solid var(--accent);
   border-radius: 4px; padding: 16px 18px; margin-bottom: 18px;
-  font-family: Georgia, serif; font-size: 15px; line-height: 1.6;
+  font-family: Georgia, "Noto Serif", "Liberation Serif", serif; font-size: 15px; line-height: 1.6;
 }
 .darling .d-meta {
   display: flex; justify-content: space-between; align-items: center;
-  margin-top: 12px; font-family: -apple-system, sans-serif;
+  margin-top: 12px; font-family: -apple-system, system-ui, "Segoe UI", Ubuntu, Cantarell, sans-serif;
   font-size: 11px; color: #999;
 }
 .darling button {
@@ -514,7 +514,7 @@ body.night .ol-hint { color: #5f5b52; }
 /* --- Stats / goals modal --- */
 .stats-nums { display: flex; gap: 26px; margin: 14px 0 18px; }
 .stats-nums div { text-align: center; }
-.stats-nums .big { font-size: 26px; color: var(--accent); font-family: Georgia, serif; }
+.stats-nums .big { font-size: 26px; color: var(--accent); font-family: Georgia, "Noto Serif", "Liberation Serif", serif; }
 .stats-nums .lbl { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 1px; margin-top: 3px; }
 .stats-row { display: flex; gap: 12px; align-items: center; margin-bottom: 12px; font-size: 13px; }
 .stats-row input {


### PR DESCRIPTION
NEO port for Linux (Fixes #1). I've done some light smoke-testing on Ubuntu, but this should probably be flagged as an experimental community port if you choose to accept the PR.

- `npm run package:linux` builds an AppImage, a .deb, and an .rpm: desktop entry (Office category), `neo` on the command line, working Chromium sandbox out of the box.
- Follows your macOS design conventions: no menu bar looming over the page (Alt to show)
- Updated hints and the Ctrl+/ cheat-sheet to show Linux key bindings (e.g. Ctrl+Shift+X instead of ⌘⇧X 
- Free counterparts for typefaces (Palatino→Palladio, the chancery drop cap stays chancery); first-run picker shows five options, which should carry through to exports and the EPUB cover (untested).
- Library should follow OS documents conventions (XDG on Linux, OneDrive-redirected on Windows) — withou moving an existing library
- Email Draft: the Gmail flow works as on Mac; AppleScript is hard-gated to darwin; a mac-synced "Apple Mail" choice falls back gracefully on Linux.
- The Silo works on X11 and does its best on Wayland.
- A few cross-platform fixes: AltGr layouts keep smart punctuation; Ctrl+/ was being eaten by GTK's select-all; trash failures can't lose words; the export toast shows just the filename on Windows; PDFs come out A4 outside Letter countries (this is a cross-platform behavior change; you can omit the last commit if you'd like to separate this out).

**Open issues**

- **No icon art included**: the Linux build currently uses the stock Electron icon (electron-builder just warns). 
- `linux.maintainer` uses your GitHub noreply address (deb requires an email but `author` doesn't have one).
- `package:all` still builds mac+win only, so your release flow doesn't suddenly need `rpmbuild`. Add `--linux` if you'd like; publishing a `package:linux` build auto-attaches `latest-linux.yml`, which should light up the existing auto-updater for AppImage users.

**Tested on Ubuntu (WSLg, arm64):** deb installs/uninstalls cleanly and launches sandboxed from the desktop entry; single-instance lock focuses the running window; library lands in the XDG Documents dir; PDF/EPUB/docx exports work; the whole first-run flow, Silo cycle, and shortcut cheat-sheet behave. This is more or leass the extent of my testing; there may be dragons (I'm not a full-time Linux user; this was mostly Claude Fable and some smoke testing in WSLg on Windows.)