### PR TITLE
Add manual Check for Update command to the NEO menu

### DIFF
--- a/app.js
+++ b/app.js
@@ -2369,6 +2369,30 @@ function showHelp() {
   bd.querySelector('.m-ok').focus();
 }
 
+// Check for Update (NEO menu) — manual, on-demand GitHub release lookup.
+// Only ever runs in response to a deliberate click, same as showHelp() above.
+async function checkForUpdate() {
+  const res = await window.neo.checkForUpdate();
+  if (res.error) { toast("Couldn't check for updates — try again later"); return; }
+  if (!res.hasUpdate) { toast("You're on the latest version"); return; }
+  const bd = document.createElement('div');
+  bd.className = 'modal-backdrop';
+  bd.innerHTML = `
+    <div class="modal" style="width:380px">
+      <h2 style="font-size:16px">NEO ${res.latestVersion} is available</h2>
+      <p>You have ${res.currentVersion}.</p>
+      <div style="text-align:right;margin-top:14px">
+        <button class="m-cancel" style="background:none;border:none;color:#888;margin-right:14px">Later</button>
+        <button class="m-ok" style="background:var(--accent);border:none;border-radius:6px;padding:7px 18px;color:#191919">View Release</button>
+      </div>
+    </div>`;
+  document.body.appendChild(bd);
+  const close = () => bd.remove();
+  bd.querySelector('.m-cancel').onclick = close;
+  bd.querySelector('.m-ok').onclick = () => { window.neo.openExternal(res.releaseUrl); close(); };
+  bd.addEventListener('keydown', (e) => { if (e.key === 'Escape') { e.stopPropagation(); close(); } });
+}
+
 /* ================================================================== */
 /*  EXPORT + EMAIL                                                     */
 /* ================================================================== */
@@ -2783,6 +2807,7 @@ async function doEmailDraft() {
 
 window.neo.onMenu(async (msg) => {
   if (msg.type === 'help') showHelp();
+  if (msg.type === 'checkUpdate') checkForUpdate();
   if (msg.type === 'export') doExport(msg.format);
   if (msg.type === 'emailDraft') doEmailDraft();
   if (msg.type === 'emailSettings') emailSettings();

--- a/main.js
+++ b/main.js
@@ -476,7 +476,25 @@ function sendToWindow(msg) {
 function buildMenu() {
   const bodyFonts = ['Georgia', 'Palatino', 'Baskerville', 'Hoefler Text', 'Iowan Old Style'];
   const template = [
-    { role: 'appMenu' },
+    {
+      label: app.name,
+      submenu: [
+        {
+          label: 'Check for Update…',
+          click: () => sendToWindow({ type: 'checkUpdate' })
+        },
+        { type: 'separator' },
+        { role: 'about' },
+        { type: 'separator' },
+        { role: 'services' },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideOthers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' }
+      ]
+    },
     {
       label: 'File',
       submenu: [
@@ -630,6 +648,45 @@ function checkForUpdates() {
     logError('updater', err);
   }
 }
+
+// Manual update check (NEO → Check for Update…): a direct GitHub Releases
+// lookup, separate from the silent auto-updater above. Works in dev too,
+// since it doesn't require app.isPackaged or a signed build.
+function compareVersions(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const na = pa[i] || 0, nb = pb[i] || 0;
+    if (na !== nb) return na - nb;
+  }
+  return 0;
+}
+
+ipcMain.handle('update:check', async () => {
+  try {
+    const res = await fetch('https://api.github.com/repos/hughhowey/neo/releases/latest', {
+      headers: { 'User-Agent': 'NEO-App' }
+    });
+    if (!res.ok) throw new Error('GitHub API returned ' + res.status);
+    const data = await res.json();
+    const latestVersion = String(data.tag_name || '').replace(/^v/, '');
+    const currentVersion = app.getVersion();
+    return {
+      hasUpdate: !!latestVersion && compareVersions(latestVersion, currentVersion) > 0,
+      latestVersion,
+      currentVersion,
+      releaseUrl: data.html_url
+    };
+  } catch (err) {
+    logError('update', err);
+    return { error: true };
+  }
+});
+
+ipcMain.handle('shell:openExternal', (_e, url) => {
+  require('electron').shell.openExternal(url);
+  return true;
+});
 
 app.whenReady().then(() => {
   // macOS press-and-hold accent picker can open invisibly inside Chromium

--- a/preload.js
+++ b/preload.js
@@ -24,6 +24,8 @@ contextBridge.exposeInMainWorld('neo', {
   emailDraft: (payload) => ipcRenderer.invoke('email:draft', payload),
   logError: (msg) => ipcRenderer.invoke('log:error', msg),
   importPick: () => ipcRenderer.invoke('import:pick'),
+  checkForUpdate: () => ipcRenderer.invoke('update:check'),
+  openExternal: (url) => ipcRenderer.invoke('shell:openExternal', url),
   setSilo: (on) => ipcRenderer.invoke('silo:set', on),
   fullscreenEscape: () => ipcRenderer.invoke('fullscreen:escape'),
 


### PR DESCRIPTION
## Summary
- Adds a manual "Check for Update…" command to the NEO app menu (above "About NEO"), for users who want to check on demand instead of waiting for the silent background updater.
- Checks the GitHub Releases API directly (`GET /repos/hughhowey/neo/releases/latest`), independent of `electron-updater` — works in dev builds too, not just packaged/signed ones.
- Shows a dismissible modal (same visual pattern as the existing Shortcuts/Goals modals) with the new version number and a "View Release" button linking straight to the release page when an update is available; a quiet toast otherwise (already up to date, or the check failed).

## Test plan
- [x] `npm start` and open the NEO menu → Check for Update…, confirm the modal shows the correct latest version and the link opens the right release page
- [x] Verified the same check logic against the live GitHub API (update-available, up-to-date, and network-error paths) in an isolated script
- [ ] Try on Windows to confirm the menu placement/behavior matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)