### PR TITLE
Fix title page font selection

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -260,11 +260,11 @@ body.night .ol-hint { color: #5f5b52; }
   display: flex; flex-direction: column; justify-content: center;
 }
 #tp-title {
-  font-family: Georgia, serif; font-size: 34px; font-weight: 700;
+  font-family: var(--body-font); font-size: 34px; font-weight: 700;
   outline: none; min-height: 44px;
 }
 #tp-subtitle {
-  font-family: Georgia, serif; font-size: 17px; font-style: italic;
+  font-family: var(--body-font); font-size: 17px; font-style: italic;
   color: #555; margin-top: 14px; outline: none; min-height: 24px;
 }
 #tp-author {


### PR DESCRIPTION
The title and subtitle fields hardcoded Georgia instead of respecting the body typeface selected during setup.

This changes both to use var(--body-font), matching the manuscript body and first-run preview.
