### PR TITLE
Hide scrollbars until you scroll

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,16 @@ const KPH = K('⌘⇧X', 'Ctrl+Shift+X');
 const KDA = K('⌘⇧D', 'Ctrl+Shift+D');
 const KHELP = K('⌘/', 'Ctrl+/');
 
+// Scrollbars stay invisible until you scroll — then fade away again.
+// Matches NEO's "chrome only when needed" rule.
+document.addEventListener('scroll', (e) => {
+  const el = e.target;
+  if (!el || !el.classList) return;
+  el.classList.add('show-scrollbar');
+  clearTimeout(el._neoSbHide);
+  el._neoSbHide = setTimeout(() => el.classList.remove('show-scrollbar'), 750);
+}, true);
+
 function askInput(title, placeholder, value = '') {
   return new Promise((resolve) => {
     const bd = document.createElement('div');

--- a/styles.css
+++ b/styles.css
@@ -588,10 +588,22 @@ body.bright #add-shelf-btn, body.bright #import-btn { color: #b4b4b4; border-col
   box-shadow: 0 3px 14px rgba(0,0,0,0.4);
 }
 
-::-webkit-scrollbar { width: 11px; }
-::-webkit-scrollbar-thumb { background: #333; border-radius: 5px; }
-::-webkit-scrollbar-thumb:hover { background: #4a4a4a; }
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 3px;
+}
 ::-webkit-scrollbar-track { background: transparent; }
+/* Quiet chrome: the thumb only paints while the pane is actively scrolling. */
+.show-scrollbar::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.16); }
+.show-scrollbar::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.28); }
+body.bright .show-scrollbar::-webkit-scrollbar-thumb { background: rgba(0, 0, 0, 0.18); }
+body.bright .show-scrollbar::-webkit-scrollbar-thumb:hover { background: rgba(0, 0, 0, 0.3); }
+
+/* Firefox */
+* { scrollbar-width: thin; scrollbar-color: transparent transparent; }
+.show-scrollbar { scrollbar-color: rgba(255, 255, 255, 0.2) transparent; }
+body.bright .show-scrollbar { scrollbar-color: rgba(0, 0, 0, 0.22) transparent; }
 
 /* pinned notes pane: the page column shifts left to clear the pane */
 #editor-view.side-pinned #paper-scroll { left: calc(50% - 125px); }


### PR DESCRIPTION
## A note to Hugh

Thank you again for NEO. The whole point of the app—for me—is that the writing room stays quiet. Chrome appears when you need it and gets out of the way when you do not.

## Why this change

On first open of a long chapter, the default scrollbar reads as a thick gray rail down the side of the page. It is useful for a second, then it sits there looking like UI furniture. That feels slightly at odds with NEO’s rule that the interface should stay invisible until it is invited.

## What this does

- Scrollbars are **transparent by default** (manuscript, bookshelf, panes)
- While scrolling, a **thin** thumb appears briefly
- About **¾ of a second** after scrolling stops, it disappears again
- No new settings, no new dependencies—just quieter chrome

## Test plan

- [x] Open a long chapter: no persistent thick scrollbar on load
- [x] Scroll the manuscript: a thin thumb appears, then fades away when you stop
- [x] Same behavior on the bookshelf if it overflows
- [x] Night and brighter interface themes both look fine

Happy to tweak timing or thickness if you have a preference.

Made with [Cursor](https://cursor.com)