### PR TITLE
Fix caret skipping character on Backspace beside placeholder marks

### DIFF
--- a/app.js
+++ b/app.js
@@ -1092,17 +1092,13 @@ function guardMarkerDelete(e, body, chId) {
   if (!isMark(node.previousSibling) && !isMark(node.nextSibling)) return false;
 
   e.preventDefault();
+  const targetOffset = back ? r.startOffset - 1 : r.startOffset;
   const del = document.createRange();
-  if (back) {
-    del.setStart(node, r.startOffset - 1);
-    del.setEnd(node, r.startOffset);
-  } else {
-    del.setStart(node, r.startOffset);
-    del.setEnd(node, r.startOffset + 1);
-  }
+  del.setStart(node, targetOffset);
+  del.setEnd(node, targetOffset + 1);
   del.deleteContents();
   const caret = document.createRange();
-  caret.setStart(node, back ? r.startOffset - 1 : r.startOffset);
+  caret.setStart(node, targetOffset);
   caret.collapse(true);
   sel.removeAllRanges();
   sel.addRange(caret);


### PR DESCRIPTION
## Summary
Changes the guardMarkerDelete, which previously didn't account for the fact that `r` is a live DOM range that automatically decerements `r.startOffset`.


## Why
#24 remains unfixed. 

## What changed
I introduced a constant `targetOffset` which precomputes the offset to be used with `caret.setStart()`. This could have alternatively been fixed by just setting `del.setStart(node, startOffset)`, but I thought it' allows for better readability to introduce this new constant

## Risk
Low risk, it's pretty straightforward.